### PR TITLE
fix(mfa): 二段階認証のための一時コードを発行させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ curl -XPOST -H "content-type:application/json" localhost:8080/user/login --data 
 
 ### MFA
 
+fail
 ```
-curl -XPOST -H "content-type:application/json" localhost:8080/user/login --data '{"email": "test3@test.com", "password":"testtesttest"}'
+curl localhost:8080/user/mfa -XPOST -H "content-type:application/json" -H 'X-One-Time-Token:BpLnfgDsc2' --data '{"code": "123457"}'
 ```
 
 ### GetSelfInfo
@@ -47,6 +48,6 @@ curl 'localhost:8080/users?id=1'
 
 invalid token
 ```
-curl -H 'X-Access-Token:test' 'localhost:8080/users?id=1'
+curl -H 'X-Access-Token:test' 'localhost:8080/users?id=123'
 ```
 

--- a/domain/infrainterface/IOneTimeAccessInfoRepository.go
+++ b/domain/infrainterface/IOneTimeAccessInfoRepository.go
@@ -3,6 +3,8 @@ package infrainterface
 import "UserMockGo/domain/model"
 
 type IOneTimeAccessInfoRepository interface {
-	CreateOneTimeAccessInfo(userId model.UserID, code string) error
-	CheckWithCode(userId model.UserID, code string) error
+	CreateOneTimeAccessInfo(userId model.UserID) string
+	GetUserIdByOneTimeCode(code string) (model.UserID, error)
+	RemoveAccessInfo(code string)
+	IncrementRetryCount(code string)
 }

--- a/domain/infrainterface/IOneTimeAccessInfoRepository.go
+++ b/domain/infrainterface/IOneTimeAccessInfoRepository.go
@@ -1,0 +1,8 @@
+package infrainterface
+
+import "UserMockGo/domain/model"
+
+type IOneTimeAccessInfoRepository interface {
+	CreateOneTimeAccessInfo(userId model.UserID, code string) error
+	CheckWithCode(userId model.UserID, code string) error
+}

--- a/domain/model/accessInfo/accessInfo.go
+++ b/domain/model/accessInfo/accessInfo.go
@@ -1,6 +1,0 @@
-package accessInfo
-
-type AccessInfo struct {
-	AccessToken string
-	ExpiresAt   int64
-}

--- a/domain/model/identity.go
+++ b/domain/model/identity.go
@@ -1,3 +1,9 @@
 package model
 
 type UserID int64
+
+//TODO: 既存のint64へのcastはここに統一する
+//TODO:　テストも書いておく
+func (id UserID) ConvertUserIdToInt64() int64 {
+	return int64(id)
+}

--- a/domain/service/OneTimeAccessInfoService.go
+++ b/domain/service/OneTimeAccessInfoService.go
@@ -1,12 +1,58 @@
 package service
 
+import (
+	"UserMockGo/domain/infrainterface"
+	"UserMockGo/domain/model"
+)
+
 type OneTimeAccessInfoService struct {
+	oneTimeAccessInfoRepository infrainterface.IOneTimeAccessInfoRepository
+	mfaRepository               infrainterface.IMfaManager
+	tokenManager                infrainterface.ITokenManager
+	userRepository              infrainterface.IUserRepository
 }
 
-func (service OneTimeAccessInfoService) Generate() error {
-	return nil
+func NewOneTimeAccessInfoService(
+	oneTimeAccessInfoRepository infrainterface.IOneTimeAccessInfoRepository,
+	mfaRepository infrainterface.IMfaManager,
+	tokenManager infrainterface.ITokenManager,
+	userRepository infrainterface.IUserRepository,
+) OneTimeAccessInfoService {
+	return OneTimeAccessInfoService{
+		oneTimeAccessInfoRepository: oneTimeAccessInfoRepository,
+		mfaRepository:               mfaRepository,
+		tokenManager:                tokenManager,
+		userRepository:              userRepository,
+	}
 }
 
-func (service OneTimeAccessInfoService) CheckWithCode(code string) error {
-	return nil
+func (service OneTimeAccessInfoService) Generate(userId model.UserID) string {
+	code := service.oneTimeAccessInfoRepository.CreateOneTimeAccessInfo(userId)
+	return code
+}
+
+func (service OneTimeAccessInfoService) CheckWithMfaAndOneTimeCode(oneTimeCode string, mfaCode string) (string, error) {
+	userId, err := service.oneTimeAccessInfoRepository.GetUserIdByOneTimeCode(oneTimeCode)
+	if err != nil {
+		return "", err
+	}
+
+	if err := service.mfaRepository.RequireValidPairOfUserAndCode(userId, mfaCode); err != nil {
+		service.oneTimeAccessInfoRepository.IncrementRetryCount(oneTimeCode)
+		return "", err
+	}
+
+	service.oneTimeAccessInfoRepository.RemoveAccessInfo(oneTimeCode)
+
+	u, err := service.userRepository.FindById(userId)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := service.tokenManager.GenerateToken(u, true)
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
 }

--- a/domain/service/OneTimeAccessInfoService.go
+++ b/domain/service/OneTimeAccessInfoService.go
@@ -1,0 +1,12 @@
+package service
+
+type OneTimeAccessInfoService struct {
+}
+
+func (service OneTimeAccessInfoService) Generate() error {
+	return nil
+}
+
+func (service OneTimeAccessInfoService) CheckWithCode(code string) error {
+	return nil
+}

--- a/domain/service/mfaService.go
+++ b/domain/service/mfaService.go
@@ -2,50 +2,25 @@ package service
 
 import (
 	"UserMockGo/domain/infrainterface"
-	"UserMockGo/domain/model"
 	"UserMockGo/domain/model/user"
 )
 
 type MfaService struct {
-	emailNotifier  infrainterface.IEmailNotifier
-	mfaManager     infrainterface.IMfaManager
-	tokenManager   infrainterface.ITokenManager
-	userRepository infrainterface.IUserRepository
+	emailNotifier infrainterface.IEmailNotifier
+	mfaManager    infrainterface.IMfaManager
 }
 
 func NewMfaService(
-	userRepository infrainterface.IUserRepository,
 	activationNotifier infrainterface.IEmailNotifier,
-	tokenManager infrainterface.ITokenManager,
 	mfaManager infrainterface.IMfaManager,
 ) MfaService {
 	return MfaService{
-		mfaManager:     mfaManager,
-		userRepository: userRepository,
-		emailNotifier:  activationNotifier,
-		tokenManager:   tokenManager,
+		mfaManager:    mfaManager,
+		emailNotifier: activationNotifier,
 	}
 }
 
 func (service MfaService) SendCode(user user.User) error {
 	code := service.mfaManager.GenerateCode(user)
 	return service.emailNotifier.SendCode(user, code)
-}
-
-func (service MfaService) CheckCode(userId model.UserID, code string) (string, error) {
-	if err := service.mfaManager.RequireValidPairOfUserAndCode(userId, code); err != nil {
-		return "", err
-	}
-
-	u, err := service.userRepository.FindById(userId)
-	if err != nil {
-		return "", err
-	}
-
-	token, err := service.tokenManager.GenerateToken(u, true)
-	if err != nil {
-		return "", err
-	}
-
-	return token, nil
 }

--- a/domain/service/userService.go
+++ b/domain/service/userService.go
@@ -162,10 +162,10 @@ func (service UserService) Login(email userValues.Email, passString userValues.P
 		return "", err
 	}
 
-	code := service.mfaManager.GenerateCode(u)
-	if err := service.emailNotifier.SendCode(u, code); err != nil {
-		return "", err
-	}
+	//code := service.mfaManager.GenerateCode(u)
+	//if err := service.emailNotifier.SendCode(u, code); err != nil {
+	//	return "", err
+	//}
 
 	return token, nil
 }

--- a/domain/service/userService_test.go
+++ b/domain/service/userService_test.go
@@ -41,8 +41,10 @@ func TestUserService_LoginSuccess(t *testing.T) {
 	}
 
 	if code == "" {
-		t.Error("login failed")
+		t.Error("should get code")
 	}
+
+	//TODO: 出力されたコードについては、特定のユーザー情報のアクセスのためのJWTの発行のための情報になっていることが期待される。
 }
 
 func TestUserService_LoginFail(t *testing.T) {
@@ -67,11 +69,12 @@ func TestUserService_LoginFail(t *testing.T) {
 	tokenManager := jwtManager.NewTokenManagerMock()
 	userService := NewUserService(userRepository, userIdGenerator, userTokenGenerator, activationNotifier, loginInfra, tokenManager, mfaManager)
 	code, err := userService.Login("test@test.com", "testtesttesttesttest")
+
 	if err == nil {
 		t.Error("should succeed", err)
 	}
 
 	if code != "" {
-		t.Error("should not get code")
+		t.Error("should get code")
 	}
 }

--- a/domain/service/userService_test.go
+++ b/domain/service/userService_test.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"UserMockGo/infra/jwtManager"
+	"UserMockGo/infra/mfa"
+	"UserMockGo/infra/myBcryption"
+	"UserMockGo/infra/mysql"
+	"UserMockGo/infra/notifier"
+	"UserMockGo/infra/randomintgenerator"
+	"UserMockGo/infra/table"
+	"UserMockGo/infra/token"
+	"UserMockGo/lib/valueObjects/userValues"
+	"testing"
+	"time"
+)
+
+func TestUserService_LoginSuccess(t *testing.T) {
+	sampleUser := table.User{
+		ID:        123,
+		Email:     "test@test.com",
+		IsActive:  true,
+		CreatedAt: time.Now().Unix(),
+		UpdatedAt: time.Now().Unix(),
+	}
+	hashedPass, _ := myBcryption.HashPassString(userValues.PassString("testtesttesttest"))
+	samplePass := table.Password{
+		ID:       123,
+		Password: hashedPass,
+	}
+	userRepository := mysql.NewUserRepositoryMock(sampleUser, samplePass)
+	userIdGenerator := randomintgenerator.UserIdGeneratorMock{}
+	userTokenGenerator := token.UserTokenGeneratorMock{}
+	activationNotifier := notifier.NewActivationNotifier()
+	loginInfra := myBcryption.NewLoginInfraMock()
+	mfaManager := mfa.NewMfaManagerMock()
+	tokenManager := jwtManager.NewTokenManagerMock()
+	userService := NewUserService(userRepository, userIdGenerator, userTokenGenerator, activationNotifier, loginInfra, tokenManager, mfaManager)
+	code, err := userService.Login("test@test.com", "testtesttesttest")
+	if err != nil {
+		t.Error("failed", err)
+	}
+
+	if code == "" {
+		t.Error("login failed")
+	}
+}
+
+func TestUserService_LoginFail(t *testing.T) {
+	sampleUser := table.User{
+		ID:        123,
+		Email:     "test@test.com",
+		IsActive:  true,
+		CreatedAt: time.Now().Unix(),
+		UpdatedAt: time.Now().Unix(),
+	}
+	hashedPass, _ := myBcryption.HashPassString(userValues.PassString("testtesttesttest"))
+	samplePass := table.Password{
+		ID:       123,
+		Password: hashedPass,
+	}
+	userRepository := mysql.NewUserRepositoryMock(sampleUser, samplePass)
+	userIdGenerator := randomintgenerator.UserIdGeneratorMock{}
+	userTokenGenerator := token.UserTokenGeneratorMock{}
+	activationNotifier := notifier.NewActivationNotifier()
+	loginInfra := myBcryption.NewLoginInfraMock()
+	mfaManager := mfa.NewMfaManagerMock()
+	tokenManager := jwtManager.NewTokenManagerMock()
+	userService := NewUserService(userRepository, userIdGenerator, userTokenGenerator, activationNotifier, loginInfra, tokenManager, mfaManager)
+	code, err := userService.Login("test@test.com", "testtesttesttesttest")
+	if err == nil {
+		t.Error("should succeed", err)
+	}
+
+	if code != "" {
+		t.Error("should not get code")
+	}
+}

--- a/infra/mfa/mfaManagerMock.go
+++ b/infra/mfa/mfaManagerMock.go
@@ -26,7 +26,7 @@ func (manager MFAManagerMock) RequireValidPairOfUserAndCode(userId model.UserID,
 	if err != nil {
 		return errors.MyError{
 			StatusCode: http.StatusBadRequest,
-			Message:    "check your email, password and code",
+			Message:    "check your login info",
 			ErrorType:  "invalid_login_info",
 		}
 	}
@@ -34,10 +34,11 @@ func (manager MFAManagerMock) RequireValidPairOfUserAndCode(userId model.UserID,
 	if code != userCode {
 		return errors.MyError{
 			StatusCode: http.StatusBadRequest,
-			Message:    "check your email, password and code",
-			ErrorType:  "invalid_login_info",
+			Message:    "check your code",
+			ErrorType:  "invalid_mfa_info",
 		}
 	}
+
 	return nil
 }
 
@@ -45,8 +46,8 @@ func getCode(userId model.UserID) (string, error) {
 	if int(userId) == 0 {
 		return "", errors.MyError{
 			StatusCode: http.StatusBadRequest,
-			Message:    "check your email, password and code",
-			ErrorType:  "invalid_login_info",
+			Message:    "check your code",
+			ErrorType:  "invalid_mfa_info",
 		}
 	}
 	return testCode, nil

--- a/infra/myBcryption/myBcrypt.go
+++ b/infra/myBcryption/myBcrypt.go
@@ -1,4 +1,4 @@
-package bcrypt
+package myBcryption
 
 import (
 	"UserMockGo/domain/infrainterface"

--- a/infra/mysql/oneTimeAccessInfoRepositoryMock.go
+++ b/infra/mysql/oneTimeAccessInfoRepositoryMock.go
@@ -1,0 +1,66 @@
+package mysql
+
+import (
+	"UserMockGo/domain/infrainterface"
+	"UserMockGo/domain/model"
+	"UserMockGo/domain/model/errors"
+	"UserMockGo/infra/table"
+	"net/http"
+	"time"
+)
+
+type OneTimeAccessInfoRepositoryMock struct {
+	OneTimeInfos map[model.UserID]table.OneTimeAccessInfo
+}
+
+func NewOneTimeAccessInfoRepositoryMock() infrainterface.IOneTimeAccessInfoRepository {
+	return OneTimeAccessInfoRepositoryMock{OneTimeInfos: map[model.UserID]table.OneTimeAccessInfo{}}
+}
+
+func (mock OneTimeAccessInfoRepositoryMock) CreateOneTimeAccessInfo(userId model.UserID, code string) error {
+
+	// TODO: ここのcode生成はinfra層の責務にする
+	info := table.OneTimeAccessInfo{
+		OneTimeAccessCode: code,
+		UserId:            int64(userId),
+		ExpiresAt:         time.Now().Add(time.Minute * 10).Unix(),
+		RetryCount:        0,
+	}
+
+	mock.OneTimeInfos[userId] = info
+	return nil
+}
+
+// 一時的なコードが存在するかを確認
+// そのコードが
+func (mock OneTimeAccessInfoRepositoryMock) CheckWithCode(userId model.UserID, code string) error {
+
+	info, ok := mock.OneTimeInfos[userId]
+	if !ok {
+		return errors.MyError{
+			StatusCode: http.StatusNotFound,
+			Message:    "one time info not found",
+			ErrorType:  "one_time_info_not_found",
+		}
+	}
+
+	if info.RetryCount > 3 {
+		delete(mock.OneTimeInfos, userId)
+		return errors.MyError{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "one time info exceeds retry_count",
+			ErrorType:  "one_time_info_not_valid",
+		}
+	}
+
+	if info.OneTimeAccessCode != code {
+		info.RetryCount += 1
+		return errors.MyError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "code does not match",
+			ErrorType:  "code_is_not_valid",
+		}
+	}
+
+	return nil
+}

--- a/infra/mysql/oneTimeAccessInfoRepositoryMock.go
+++ b/infra/mysql/oneTimeAccessInfoRepositoryMock.go
@@ -5,39 +5,43 @@ import (
 	"UserMockGo/domain/model"
 	"UserMockGo/domain/model/errors"
 	"UserMockGo/infra/table"
+	"math/rand"
 	"net/http"
 	"time"
 )
 
 type OneTimeAccessInfoRepositoryMock struct {
-	OneTimeInfos map[model.UserID]table.OneTimeAccessInfo
+	OneTimeInfos map[string]table.OneTimeAccessInfo
 }
 
 func NewOneTimeAccessInfoRepositoryMock() infrainterface.IOneTimeAccessInfoRepository {
-	return OneTimeAccessInfoRepositoryMock{OneTimeInfos: map[model.UserID]table.OneTimeAccessInfo{}}
+	return OneTimeAccessInfoRepositoryMock{OneTimeInfos: map[string]table.OneTimeAccessInfo{}}
 }
 
-func (mock OneTimeAccessInfoRepositoryMock) CreateOneTimeAccessInfo(userId model.UserID, code string) error {
+const rs2Letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
-	// TODO: ここのcode生成はinfra層の責務にする
+func (mock OneTimeAccessInfoRepositoryMock) CreateOneTimeAccessInfo(userId model.UserID) string {
+
+	b := make([]byte, 10)
+	for i := range b {
+		b[i] = rs2Letters[rand.Intn(len(rs2Letters))]
+	}
+
 	info := table.OneTimeAccessInfo{
-		OneTimeAccessCode: code,
-		UserId:            int64(userId),
+		OneTimeAccessCode: string(b),
+		UserId:            userId,
 		ExpiresAt:         time.Now().Add(time.Minute * 10).Unix(),
 		RetryCount:        0,
 	}
 
-	mock.OneTimeInfos[userId] = info
-	return nil
+	mock.OneTimeInfos[string(b)] = info
+	return string(b)
 }
 
-// 一時的なコードが存在するかを確認
-// そのコードが
-func (mock OneTimeAccessInfoRepositoryMock) CheckWithCode(userId model.UserID, code string) error {
-
-	info, ok := mock.OneTimeInfos[userId]
+func (mock OneTimeAccessInfoRepositoryMock) GetUserIdByOneTimeCode(code string) (model.UserID, error) {
+	info, ok := mock.OneTimeInfos[code]
 	if !ok {
-		return errors.MyError{
+		return 0, errors.MyError{
 			StatusCode: http.StatusNotFound,
 			Message:    "one time info not found",
 			ErrorType:  "one_time_info_not_found",
@@ -45,22 +49,35 @@ func (mock OneTimeAccessInfoRepositoryMock) CheckWithCode(userId model.UserID, c
 	}
 
 	if info.RetryCount > 3 {
-		delete(mock.OneTimeInfos, userId)
-		return errors.MyError{
+		delete(mock.OneTimeInfos, code)
+		return 0, errors.MyError{
 			StatusCode: http.StatusInternalServerError,
 			Message:    "one time info exceeds retry_count",
 			ErrorType:  "one_time_info_not_valid",
 		}
 	}
 
-	if info.OneTimeAccessCode != code {
-		info.RetryCount += 1
-		return errors.MyError{
-			StatusCode: http.StatusBadRequest,
-			Message:    "code does not match",
-			ErrorType:  "code_is_not_valid",
-		}
+	return info.UserId, nil
+}
+
+func (mock OneTimeAccessInfoRepositoryMock) RemoveAccessInfo(code string) {
+	_, ok := mock.OneTimeInfos[code]
+	if !ok {
+		return
 	}
 
-	return nil
+	delete(mock.OneTimeInfos, code)
+	return
+}
+
+func (mock OneTimeAccessInfoRepositoryMock) IncrementRetryCount(code string) {
+
+	info, ok := mock.OneTimeInfos[code]
+	if !ok {
+		return
+	}
+
+	info.RetryCount += 1
+	mock.OneTimeInfos[code] = info
+	return
 }

--- a/infra/mysql/userRepositoryMock.go
+++ b/infra/mysql/userRepositoryMock.go
@@ -4,7 +4,7 @@ import (
 	"UserMockGo/domain/infrainterface"
 	"UserMockGo/domain/model"
 	"UserMockGo/domain/model/user"
-	"UserMockGo/infra/bcrypt"
+	"UserMockGo/infra/myBcryption"
 	"UserMockGo/infra/table"
 	"UserMockGo/lib/valueObjects/userValues"
 	"fmt"
@@ -43,7 +43,7 @@ func NewUserRepositoryMock(testUser table.User, testPass table.Password) infrain
 		ActivationTokenExpiresAt: 2145884400,
 	})
 	passwords := []table.Password{}
-	hashedPass, _ := bcrypt.HashPassString(userValues.PassString(os.Getenv("TEST_PASS")))
+	hashedPass, _ := myBcryption.HashPassString(userValues.PassString(os.Getenv("TEST_PASS")))
 	passwords = append(passwords, table.Password{
 		ID:       3,
 		Password: hashedPass,

--- a/infra/table/oneTimeAcces.go
+++ b/infra/table/oneTimeAcces.go
@@ -1,8 +1,10 @@
 package table
 
+import "UserMockGo/domain/model"
+
 type OneTimeAccessInfo struct {
 	OneTimeAccessCode string
-	UserId            int64
+	UserId            model.UserID
 	ExpiresAt         int64
 	RetryCount        int64
 }

--- a/infra/table/oneTimeAcces.go
+++ b/infra/table/oneTimeAcces.go
@@ -1,0 +1,8 @@
+package table
+
+type OneTimeAccessInfo struct {
+	OneTimeAccessCode string
+	UserId            int64
+	ExpiresAt         int64
+	RetryCount        int64
+}

--- a/infra/table/password.go
+++ b/infra/table/password.go
@@ -2,7 +2,7 @@ package table
 
 import (
 	"UserMockGo/domain/model/user"
-	"UserMockGo/infra/bcrypt"
+	"UserMockGo/infra/myBcryption"
 )
 
 type Password struct {
@@ -11,7 +11,7 @@ type Password struct {
 }
 
 func MapFromUserPasswordModel(password user.Password) (Password, error) {
-	hp, err := bcrypt.HashPassString(password.Password)
+	hp, err := myBcryption.HashPassString(password.Password)
 	if err != nil {
 		return Password{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -39,12 +39,14 @@ func main() {
 	loginInfra := myBcryption.NewLoginInfraMock()
 	mfaManager := mfa.NewMfaManagerMock()
 	tokenManager := jwtManager.NewTokenManagerMock()
+	oneTimeAccessInfoRepo := mysql.NewOneTimeAccessInfoRepositoryMock()
 	userService := service.NewUserService(userRepository, userIdGenerator, userTokenGenerator, activationNotifier, loginInfra, tokenManager,
-		mfaManager)
+		mfaManager, oneTimeAccessInfoRepo)
+	oneTImeAccessInfoService := service.NewOneTimeAccessInfoService(oneTimeAccessInfoRepo, mfaManager, tokenManager, userRepository)
 	authorizationService := service.NewAuthorizationService(tokenManager)
-	mfaService := service.NewMfaService(userRepository, activationNotifier, tokenManager, mfaManager)
+	mfaService := service.NewMfaService(activationNotifier, mfaManager)
 	userHandler := handler.NewUserHandler(userService, authorizationService)
-	mfaHandler := handler.NewMfaHandler(mfaService, authorizationService)
+	mfaHandler := handler.NewMfaHandler(mfaService, authorizationService, oneTImeAccessInfoService)
 	e.GET("/", func(c echo.Context) error {
 		return c.String(http.StatusOK, "Hello, World!")
 	})

--- a/main.go
+++ b/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"UserMockGo/domain/service"
-	"UserMockGo/infra/bcrypt"
 	"UserMockGo/infra/jwtManager"
 	"UserMockGo/infra/mfa"
+	"UserMockGo/infra/myBcryption"
 	"UserMockGo/infra/mysql"
 	"UserMockGo/infra/notifier"
 	"UserMockGo/infra/randomintgenerator"
@@ -27,7 +27,7 @@ func main() {
 		CreatedAt: time.Now().Unix(),
 		UpdatedAt: time.Now().Unix(),
 	}
-	hashedPass, _ := bcrypt.HashPassString(userValues.PassString(os.Getenv("USER_MOCK_GO_USER_PASS")))
+	hashedPass, _ := myBcryption.HashPassString(userValues.PassString(os.Getenv("USER_MOCK_GO_USER_PASS")))
 	samplePass := table.Password{
 		ID:       123,
 		Password: hashedPass,
@@ -36,13 +36,13 @@ func main() {
 	userIdGenerator := randomintgenerator.UserIdGeneratorMock{}
 	userTokenGenerator := token.UserTokenGeneratorMock{}
 	activationNotifier := notifier.NewActivationNotifier()
-	LoginInfra := bcrypt.NewLoginInfraMock()
-	MfaManager := mfa.NewMfaManagerMock()
+	loginInfra := myBcryption.NewLoginInfraMock()
+	mfaManager := mfa.NewMfaManagerMock()
 	tokenManager := jwtManager.NewTokenManagerMock()
-	userService := service.NewUserService(userRepository, userIdGenerator, userTokenGenerator, activationNotifier, LoginInfra, tokenManager,
-		MfaManager)
+	userService := service.NewUserService(userRepository, userIdGenerator, userTokenGenerator, activationNotifier, loginInfra, tokenManager,
+		mfaManager)
 	authorizationService := service.NewAuthorizationService(tokenManager)
-	mfaService := service.NewMfaService(userRepository, activationNotifier, tokenManager, MfaManager)
+	mfaService := service.NewMfaService(userRepository, activationNotifier, tokenManager, mfaManager)
 	userHandler := handler.NewUserHandler(userService, authorizationService)
 	mfaHandler := handler.NewMfaHandler(mfaService, authorizationService)
 	e.GET("/", func(c echo.Context) error {

--- a/web/handler/userHandler.go
+++ b/web/handler/userHandler.go
@@ -106,7 +106,11 @@ func (handler UserHandler) Login(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, "Login is failed: "+err.Error())
 	}
 
-	return c.JSON(http.StatusOK, token)
+	response := map[string]interface{}{
+		"session_token": token,
+	}
+
+	return c.JSON(http.StatusOK, response)
 }
 
 func (handler UserHandler) GetUserInfo(c echo.Context) error {


### PR DESCRIPTION
# why

二段階認証で、何度もOneTimePasswordを入力できるようにしているのはおかしいから。

まだガワしか作っていないのでDraft

#47 #53 #52 

# what

- chore(*): rename
- chore(*): add tests for UserService_Login
- chore(*): add comment
- chore(*): remove accessInfo from model-layer
- feat(infra-interface): add IOneTimeAccessInfoRepository.go
- feat(infra): add oneTimeAccessInfoRepositoryMock.go
- chore(service): OneTimeAccessInfoService.goのガワだけ作成
- feat(service): OneTimeAccessInfoService.goの中身とRepositoryのinterface
- feat(repository): OneTimeAccessInfoのRepository層を作成
- chore(infra): エラーメッセージの修正
- feat(service): userServiceでmfaのcodeと一時コードの一致をやらせる
- feat(handler): mfaHandlerに一時コードserviceを見るようにしてチェックさせる
- chore(test): userServiceでテストする
- chore(*): READMEの追記