### PR TITLE
chore(*): use ConvertUserIdToInt64()

### DIFF
--- a/infra/mysql/userRepositoryMock.go
+++ b/infra/mysql/userRepositoryMock.go
@@ -87,7 +87,7 @@ func (repo UserRepositoryMock) CreateUserTransactional(user user.User, pass user
 func (repo UserRepositoryMock) ActivateUserTransactional(user user.User, activation user.Activation) error {
 	users := []table.User{}
 	for _, u := range *repo.Users {
-		if u.ID != int64(user.ID) {
+		if u.ID != user.ID.ConvertUserIdToInt64() {
 			users = append(users, u)
 		} else {
 			user.IsActive = true
@@ -99,7 +99,7 @@ func (repo UserRepositoryMock) ActivateUserTransactional(user user.User, activat
 
 	activations := []table.Activation{}
 	for _, a := range *repo.Activations {
-		if a.ID != int64(activation.ID) {
+		if a.ID != activation.ID.ConvertUserIdToInt64() {
 			activations = append(activations, a)
 		}
 	}
@@ -156,7 +156,7 @@ func (repo UserRepositoryMock) FindById(id model.UserID) (user.User, error) {
 		}, nil
 	default:
 		for _, u := range *repo.Users {
-			if u.ID == int64(id) {
+			if u.ID == id.ConvertUserIdToInt64() {
 				return u.MapToUserModel()
 			}
 		}
@@ -181,7 +181,7 @@ func (repo UserRepositoryMock) FindByUserIdAndToken(userId model.UserID, token s
 			}, nil
 		default:
 			for _, a := range *repo.Activations {
-				if a.ID == int64(userId) && a.ActivationToken == token {
+				if a.ID == userId.ConvertUserIdToInt64() && a.ActivationToken == token {
 					return a.MapToActivationModel()
 				}
 			}
@@ -200,7 +200,7 @@ func (repo UserRepositoryMock) ReissueOfActivationTransactional(activation user.
 	}
 
 	for _, a := range *repo.Activations {
-		if a.ID != int64(activation.ID) {
+		if a.ID != activation.ID.ConvertUserIdToInt64() {
 			activations = append(activations, a)
 		} else {
 			activations = append(activations, newActivation)
@@ -213,7 +213,7 @@ func (repo UserRepositoryMock) ReissueOfActivationTransactional(activation user.
 
 func (repo UserRepositoryMock) GetHashedPassword(id model.UserID) (string, error) {
 	for _, p := range *repo.Passwords {
-		if p.ID == int64(id) {
+		if p.ID == id.ConvertUserIdToInt64() {
 			return p.MapToHashedString(), nil
 		}
 	}

--- a/infra/table/activation.go
+++ b/infra/table/activation.go
@@ -13,7 +13,7 @@ type Activation struct {
 
 func MapFromUserActivationModel(activation user.Activation) (Activation, error) {
 	return Activation{
-		ID:                       int64(activation.ID),
+		ID:                       activation.ID.ConvertUserIdToInt64(),
 		ActivationToken:          activation.ActivationToken,
 		ActivationTokenExpiresAt: activation.ActivationTokenExpiresAt,
 	}, nil

--- a/infra/table/password.go
+++ b/infra/table/password.go
@@ -17,7 +17,7 @@ func MapFromUserPasswordModel(password user.Password) (Password, error) {
 	}
 
 	return Password{
-		ID:       int64(password.ID),
+		ID:       password.ID.ConvertUserIdToInt64(),
 		Password: hp,
 	}, nil
 }

--- a/infra/table/user.go
+++ b/infra/table/user.go
@@ -16,7 +16,7 @@ type User struct {
 
 func MapFromUserModel(user user.User) (User, error) {
 	return User{
-		ID:        int64(user.ID),
+		ID:        user.ID.ConvertUserIdToInt64(),
 		Email:     string(user.Email),
 		IsActive:  user.IsActive,
 		CreatedAt: user.CreatedAt,


### PR DESCRIPTION
# why

castの共通化

Closes: #53 

# what

- chore(*): use ConvertUserIdToInt64()
